### PR TITLE
better support for vendor directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-GoSweep
-=======
+# GoSweep
 
 The script does automatic checking on a Go package and its sub-packages, including:
 
-1. [gofmt](http://golang.org/cmd/gofmt/)
-2. [goimports](https://github.com/bradfitz/goimports)
-3. [golint](https://github.com/golang/lint)
-4. [go vet](http://golang.org/cmd/vet)
-5. [race detector](http://blog.golang.org/race-detector)
-6. [test coverage](http://blog.golang.org/cover) on package and its
-   sub-packages.
+1. [gofmt][gofmt]
+2. [goimports][goimports]
+3. [golint][golint]
+4. [go vet][go_vet]
+5. [race detector][race_detector]
+6. [test coverage][test_coverage] on package and its sub-packages.
 
 Migrated from my [Gist](https://gist.github.com/hailiang/0f22736320abe6be71ce).
 
+[gofmt]:	http://golang.org/cmd/gofmt/	"gofmt"
+[goimports]:	https://godoc.org/golang.org/x/tools/cmd/goimports	"golang.org/x/tools/cmd/goimports"
+[golint]:	https://github.com/golang/lint	"golang/lint"
+[go_vet]:	http://golang.org/cmd/vet	"go vet"
+[race_detector]:	http://blog.golang.org/race-detector	"race detector"
+[test_coverage]:	http://blog.golang.org/cover	"test coverage"


### PR DESCRIPTION
@h12w I've tweaked this a bit to make it work better with vendor directories.

I now use a `for` loop and execute each of the commands (exception for code coverage and `goveralls`) inside it.

I've also updated the `goimports` link and print some messages on the terminal to make it easier to understand at which step the build/test/etc breaks.

I've also added the output of `go test` to `stdout` since it started becoming a problem.

feel free to merge or not.