### PR TITLE
README.md: updated .travis.yml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ language: go
 cache:
   directories:
     - ${GOPATH}/src/github.com/${TRAVIS_REPO_SLUG}/vendor
-    - ${GOPATH}/src/github.com/client9/misspell
-    - ${GOPATH}/src/github.com/fzipp/gocyclo
+    - ${GOPATH}/src/github.com/fzipp
     - ${GOPATH}/src/github.com/h12w
     - ${GOPATH}/src/github.com/Masterminds
     - ${GOPATH}/src/github.com/mattn


### PR DESCRIPTION
this fixes the example to overcome these failures:

```
The command "go get -v -u github.com/fzipp/gocyclo" failed and exited with 1 during .
```
[here](https://travis-ci.org/steenzout/go-env/jobs/225829184)

and

```
The command "go get -v -u github.com/client9/misspell/cmd/misspell" failed and exited with 1 during .
```
[here](https://travis-ci.org/steenzout/go-env/jobs/225823424)