### PR TITLE
when repo is not registered on coveralls.io it fails all tests on travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To setup all the dependencies need to run the script do:
 ```
 $ go get -v github.com/client9/misspell/cmd/misspell
 $ go get -v github.com/fzipp/gocyclo
+$ go get -v -u github.com/gordonklaus/ineffassign
 $ go get -v github.com/h12w/gosweep
 $ go get -v github.com/mattn/goveralls
 ```
@@ -54,6 +55,7 @@ cache:
   directories:
     - ${GOPATH}/src/github.com/${TRAVIS_REPO_SLUG}/vendor
     - ${GOPATH}/src/github.com/fzipp
+    - ${GOPATH}/src/github.com/gordonklaus
     - ${GOPATH}/src/github.com/h12w
     - ${GOPATH}/src/github.com/Masterminds
     - ${GOPATH}/src/github.com/mattn
@@ -70,6 +72,7 @@ env:
 install:
   - go get -v github.com/client9/misspell/cmd/misspell
   - go get -v github.com/fzipp/gocyclo
+  - go get -v github.com/gordonklaus/ineffassign
   - go get -v github.com/h12w/gosweep
   - go get -v github.com/mattn/goveralls
   - go get -v github.com/Masterminds/glide

--- a/README.md
+++ b/README.md
@@ -57,10 +57,7 @@ cache:
   directories:
     - ${GOPATH}/src/github.com/${TRAVIS_REPO_SLUG}/vendor
     - ${GOPATH}/src/github.com/fzipp
-<<<<<<< HEAD
-=======
     - ${GOPATH}/src/github.com/golang
->>>>>>> h12w-master
     - ${GOPATH}/src/github.com/gordonklaus
     - ${GOPATH}/src/github.com/h12w
     - ${GOPATH}/src/github.com/mattn
@@ -77,10 +74,7 @@ env:
 install:
   - go get -v github.com/client9/misspell/cmd/misspell
   - go get -v github.com/fzipp/gocyclo
-<<<<<<< HEAD
-=======
   - go get -v github.com/golang/lint/golint
->>>>>>> h12w-master
   - go get -v github.com/gordonklaus/ineffassign
   - go get -v github.com/h12w/gosweep
   - go get -v github.com/mattn/goveralls

--- a/gosweep.sh
+++ b/gosweep.sh
@@ -86,9 +86,9 @@ go tool cover -func profile.cov
 if [ -n "${CI_SERVICE+1}" ]; then
     echo "goveralls with ${CI_SERVICE}"
     if [ -n "${COVERALLS_TOKEN+1}" ]; then
-        goveralls -coverprofile=profile.cov -service=$CI_SERVICE -repotoken $COVERALLS_TOKEN
+        goveralls -coverprofile=profile.cov -service=$CI_SERVICE -repotoken $COVERALLS_TOKEN || echo "Could not send code coverage to coveralls.io! Be sure you registered this repo."
     else
-        goveralls -coverprofile=profile.cov -service=$CI_SERVICE
+        goveralls -coverprofile=profile.cov -service=$CI_SERVICE || echo "Could not send code coverage to coveralls.io! Be sure you registered this repo."
     fi
 fi
 


### PR DESCRIPTION
let tests continue and print user-friendly error if the repo is not registered on coveralls.io.